### PR TITLE
Change DB connection string to localdb and add City seed data

### DIFF
--- a/ServerSideSPA/ServerSideSPA/Models/EmployeeDBContext.cs
+++ b/ServerSideSPA/ServerSideSPA/Models/EmployeeDBContext.cs
@@ -30,6 +30,12 @@ namespace ServerSideSPA.Models
                 entity.Property(e => e.CityName)
                     .HasMaxLength(20)
                     .IsUnicode(false);
+
+                entity.HasData(new City { CityId = 1, CityName = "Tokyo" });
+                entity.HasData(new City { CityId = 2, CityName = "Jakarta" });
+                entity.HasData(new City { CityId = 3, CityName = "Delhi" });
+                entity.HasData(new City { CityId = 4, CityName = "Manilla" });
+                entity.HasData(new City { CityId = 5, CityName = "Seoul" });
             });
 
             modelBuilder.Entity<Employee>(entity =>

--- a/ServerSideSPA/ServerSideSPA/appsettings.json
+++ b/ServerSideSPA/ServerSideSPA/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=ANKIT-LENOVO;Initial Catalog=EmployeeDB;User Id=test;Password=sa;"
+    "DefaultConnection": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=EmployeeDB;User Id=test;Password=sa;Trusted_Connection=True"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Hello Ankit, 

thank you for sharing your project, it was very useful for me.

I have added two improvements

1. The connection string in appsettings points to your local computer, so anyone who wants to use it has to change it. I suggest to change it to  Data Source=(localdb)\\mssqllocaldb
2. I have added some seed data so that you can create employes right after running the project without needing to add cities manually.

What do you think about it?